### PR TITLE
Chore 110815626 add sentry

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,23 @@ logger.error('Error message', meta, err);
 app.use(logger.middleware());
 ```
 
+### Report to [Sentry](https://getsentry.com)
+
+If error object is passed to logger's logging methods, e.g. `error`, in addition to sending data to defined transporter (most likely Loggly), the error will also be sent to Sentry.
+
+```js
+var Log = require('@spanishdict/pn-logging').Log;
+var logger = new Log(config);
+
+logger.error('Error message', {
+  tags: {key: 'value'}
+}, err);
+```
+
+Refer to [sentry docs](https://docs.getsentry.com/hosted/clients/node/usage/#optional-attributes).
+
+`tags`, `fingerprint`, and `level` properties of log meta object will be mapped to related sentry optional attributes. All other meta properties will become `extra` property in sentry optional attributes.
+
 ### Config
 
 The `config` object passed to `Log` constructor should look like:
@@ -43,6 +60,12 @@ var config = {
         token: process.env.LOGGLY_TOKEN
       }
     }
-  ]
+  ],
+  sentry: {
+    // specify `false` here to disable sentry
+    dsn: 'https://*****@app.getsentry.com/xxxxx',
+    // pass directly to raven constructor refer to https://goo.gl/9Ud7Mz
+    options: {}
+  }
 };
 ```

--- a/index.js
+++ b/index.js
@@ -90,8 +90,13 @@ function Log(options) {
   this._winexConstructor = winex.factory(winstonLog, {}, doNop);
   this.middleware = this._winexConstructor.middleware;
 
-  this.ravenClient =
-    new raven.Client(options.sentry.dsn, options.sentry.options);
+  if (sentry) {
+    this.ravenClient = new raven.Client(
+      options.sentry.dsn,
+      options.sentry.options);
+  } else {
+    this.ravenClient = new raven.Client(false);
+  }
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -90,7 +90,7 @@ function Log(options) {
   this._winexConstructor = winex.factory(winstonLog, {}, doNop);
   this.middleware = this._winexConstructor.middleware;
 
-  if (sentry) {
+  if (options.sentry) {
     this.ravenClient = new raven.Client(
       options.sentry.dsn,
       options.sentry.options);

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
   },
   "homepage": "https://github.com/spanishdict/pn-logging",
   "dependencies": {
+    "lodash": "3.10.1",
+    "raven": "0.9.0",
     "winex": "0.0.6",
     "winston": "2.1.1",
     "winston-loggly": "1.2.0"

--- a/test/index.js
+++ b/test/index.js
@@ -23,7 +23,7 @@ describe('index', function () {
   describe('Log constructor', function () {
 
     it('should return a Log instance', function () {
-      var log = new index.Log({ transports: [] });
+      var log = new index.Log({ transports: [], sentry: {} });
 
       expect(log).to.be.an.instanceOf(index.Log);
     });
@@ -36,49 +36,49 @@ describe('index', function () {
     });
 
     it('should have a debug method', function () {
-      var log = new index.Log({ transports: [] });
+      var log = new index.Log({ transports: [], sentry: {} });
 
       expect(log).to.respondTo('debug');
     });
 
     it('should have a info method', function () {
-      var log = new index.Log({ transports: [] });
+      var log = new index.Log({ transports: [], sentry: {} });
 
       expect(log).to.respondTo('info');
     });
 
     it('should have a notice method', function () {
-      var log = new index.Log({ transports: [] });
+      var log = new index.Log({ transports: [], sentry: {} });
 
       expect(log).to.respondTo('notice');
     });
 
     it('should have a warning method', function () {
-      var log = new index.Log({ transports: [] });
+      var log = new index.Log({ transports: [], sentry: {} });
 
       expect(log).to.respondTo('warning');
     });
 
     it('should have a error method', function () {
-      var log = new index.Log({ transports: [] });
+      var log = new index.Log({ transports: [], sentry: {} });
 
       expect(log).to.respondTo('error');
     });
 
     it('should have a crit method', function () {
-      var log = new index.Log({ transports: [] });
+      var log = new index.Log({ transports: [], sentry: {} });
 
       expect(log).to.respondTo('crit');
     });
 
     it('should have a alert method', function () {
-      var log = new index.Log({ transports: [] });
+      var log = new index.Log({ transports: [], sentry: {} });
 
       expect(log).to.respondTo('alert');
     });
 
     it('should have a emerg method', function () {
-      var log = new index.Log({ transports: [] });
+      var log = new index.Log({ transports: [], sentry: {} });
 
       expect(log).to.respondTo('emerg');
     });
@@ -104,7 +104,8 @@ describe('index', function () {
             level: 'debug',
             __log: spy
           }
-        }]
+        }],
+        sentry: {}
       });
     });
 
@@ -146,18 +147,98 @@ describe('index', function () {
   describe('middleware', function () {
 
     it('should have middleware on the instance', function () {
-      var log = new index.Log({ transports: [] });
+      var log = new index.Log({ transports: [], sentry: {} });
 
       expect(log).to.have.property('middleware');
       expect(log.middleware).to.be.a('function');
     });
 
     it('should produce a middleware function', function () {
-      var log = new index.Log({ transports: [] });
+      var log = new index.Log({ transports: [], sentry: {} });
       var middleware = log.middleware();
 
       expect(middleware).to.be.a('function');
       expect(middleware).to.have.length(3);
+    });
+
+  });
+
+  describe('_getSentryMeta', function () {
+
+    it('should return null if meta is not defined', function () {
+      var result = index._getSentryMeta();
+
+      expect(result).to.be.null;
+    });
+
+    it('should add tags property', function () {
+      var input = {
+        tags: {
+          key1: 'value1',
+          key2: 'value2'
+        }
+      };
+
+      var result = index._getSentryMeta(input);
+
+      expect(result).to.have.property('tags');
+      expect(result.tags).to.eql({
+        key1: 'value1',
+        key2: 'value2'
+      });
+    });
+
+    it('should add fingerprint property', function () {
+      var input = {
+        fingerprint: 'fingerprintValue'
+      };
+
+      var result = index._getSentryMeta(input);
+
+      expect(result).to.have.property('fingerprint', 'fingerprintValue');
+    });
+
+    it('should add fingerprint property', function () {
+      var input = {
+        level: 'error'
+      };
+
+      var result = index._getSentryMeta(input);
+
+      expect(result).to.have.property('level', 'error');
+    });
+
+    it('should exclude tags, fingerprint, and level in extra', function () {
+      var input = {
+        level: 'error',
+        tags: 'tagsValue',
+        fingerprint: 'fingerprintValue',
+        key1: 'value1',
+        key2: 'value2'
+      };
+
+      var result = index._getSentryMeta(input);
+
+      expect(result).to.have.property('extra');
+      expect(result.extra).to.not.have.property('level');
+      expect(result.extra).to.not.have.property('tags');
+      expect(result.extra).to.not.have.property('fingerprint');
+    });
+
+    it('should include other property in extra', function () {
+      var input = {
+        level: 'error',
+        tags: 'tagsValue',
+        fingerprint: 'fingerprintValue',
+        key1: 'value1',
+        key2: 'value2'
+      };
+
+      var result = index._getSentryMeta(input);
+
+      expect(result).to.have.property('extra');
+      expect(result.extra).to.have.property('key1', 'value1');
+      expect(result.extra).to.have.property('key2', 'value2');
     });
 
   });

--- a/test/index.js
+++ b/test/index.js
@@ -198,7 +198,7 @@ describe('index', function () {
       expect(result).to.have.property('fingerprint', 'fingerprintValue');
     });
 
-    it('should add fingerprint property', function () {
+    it('should add level property', function () {
       var input = {
         level: 'error'
       };


### PR DESCRIPTION
@ahaurw01 Add sentry. External API remains the same. When error object is a detected, it will send to sentry. We can also specify meta being sent to sentry (details see updated README).

/cc @danpaz 
