### PR TITLE
Include env to tags

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ var winston = require('winston');
 var winex = require('winex');
 var raven = require('raven');
 var omit = require('lodash/object/omit');
+var assign = require('lodash/object/assign');
 
 var sysLogLevels;
 
@@ -85,9 +86,7 @@ function Log(options) {
   };
 
   winstonLog = new winston.Logger(winstonOpts);
-  // Possibly put this in config instead of reading process.env.
-  doNop = {nop: !!(process.env.NODE_ENV === 'test')};
-  this._winexConstructor = winex.factory(winstonLog, {}, doNop);
+  this._winexConstructor = winex.factory(winstonLog, {});
   this.middleware = this._winexConstructor.middleware;
 
   if (options.sentry) {
@@ -138,7 +137,20 @@ function _getSentryMeta(meta) {
     return null;
   }
 
-  tags = meta.tags;
+  if (!meta.tags) {
+    tags = {
+      env: process.env.NODE_ENV || 'development'
+    };
+  } else {
+    tags = meta.tags;
+
+    if (tags.env == null) {
+      tags = assign({}, tags, {
+        env: process.env.NODE_ENV || 'development'
+      });
+    }
+  }
+
   fingerprint = meta.fingerprint;
   level = meta.level;
   extra = omit(meta, ['tags', 'fingerprint', 'level']);

--- a/index.js
+++ b/index.js
@@ -67,7 +67,6 @@ function Log(options) {
   var logTransports;
   var winstonOpts;
   var winstonLog;
-  var doNop;
 
   if (!options || !options.transports) {
     throw new Error('No transports found');

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "scripts": {
     "style": "eslint index.js test",
-    "test": "istanbul cover node_modules/.bin/_mocha -- --recursive test",
+    "test": "env NODE_ENV=test istanbul cover node_modules/.bin/_mocha -- --recursive test",
     "check": "npm run style && npm test",
     "watch:test": "mocha -w --recursive test"
   }

--- a/test/index.js
+++ b/test/index.js
@@ -182,10 +182,8 @@ describe('index', function () {
       var result = index._getSentryMeta(input);
 
       expect(result).to.have.property('tags');
-      expect(result.tags).to.eql({
-        key1: 'value1',
-        key2: 'value2'
-      });
+      expect(result.tags).to.have.property('key1', 'value1');
+      expect(result.tags).to.have.property('key2', 'value2');
     });
 
     it('should add fingerprint property', function () {
@@ -239,6 +237,60 @@ describe('index', function () {
       expect(result).to.have.property('extra');
       expect(result.extra).to.have.property('key1', 'value1');
       expect(result.extra).to.have.property('key2', 'value2');
+    });
+
+    it('should add tags if no tags are defined', function () {
+      var input = {};
+
+      var result = index._getSentryMeta(input);
+
+      expect(result).to.have.property('extra');
+      expect(result.tags).to.have.property('env', 'test');
+    });
+
+    it('should add env to tags if no env is defined', function () {
+      var input = {
+        tags: {
+          key1: 'value1',
+          key2: 'value2'
+        }
+      };
+
+      var result = index._getSentryMeta(input);
+
+      expect(result.tags).to.have.property('env', 'test');
+    });
+
+    it('should not change env in tags if env is defined', function () {
+      var input = {
+        tags: {
+          key1: 'value1',
+          key2: 'value2',
+          env: 'production'
+        }
+      };
+
+      var result = index._getSentryMeta(input);
+
+      expect(result.tags).to.have.property('env', 'production');
+    });
+
+    it('should not mutate input', function () {
+      var input = {
+        tags: {
+          key1: 'value1',
+          key2: 'value2'
+        }
+      };
+
+      var result = index._getSentryMeta(input);
+
+      expect(input).to.eql({
+        tags: {
+          key1: 'value1',
+          key2: 'value2'
+        }
+      });
     });
 
   });

--- a/test/index.js
+++ b/test/index.js
@@ -283,7 +283,7 @@ describe('index', function () {
         }
       };
 
-      var result = index._getSentryMeta(input);
+      index._getSentryMeta(input);
 
       expect(input).to.eql({
         tags: {


### PR DESCRIPTION
@ahaurw01 This make sure when we send errors to sentry, env is included automatically, manually config this is tedious.

Also removed the `doNop = {nop: !!(process.env.NODE_ENV === 'test')};`, we should set transport to disable logging in tests.

/cc @danpaz 
